### PR TITLE
Fix Chrome dev package name

### DIFF
--- a/svgomg/src/main/java/org/chromium/twa/svgomg/TwaSessionHelper.java
+++ b/svgomg/src/main/java/org/chromium/twa/svgomg/TwaSessionHelper.java
@@ -44,7 +44,7 @@ import java.util.List;
  */
 public class TwaSessionHelper implements ServiceConnectionCallback {
     private static final String TAG = TwaSessionHelper.class.getSimpleName();
-    private static final List<String> CHROME_PACKAGES = Arrays.asList("com.chrome.canary");
+    private static final List<String> CHROME_PACKAGES = Arrays.asList("com.chrome.dev");
     private static final TwaSessionHelper INSTANCE = new TwaSessionHelper();
 
     private CustomTabsSession mCustomTabsSession;


### PR DESCRIPTION
As seen on https://developers.google.com/web/updates/2017/10/using-twa, and by testing in a real release build myself, the TWA fullscreen works currently only on [Chrome Development](https://play.google.com/store/apps/details?id=com.chrome.dev&hl=en)