### PR TITLE
Bug fix: setToolbarColor correct

### DIFF
--- a/customtabs/src/android/support/customtabs/trusted/LauncherActivity.java
+++ b/customtabs/src/android/support/customtabs/trusted/LauncherActivity.java
@@ -138,8 +138,7 @@ public class LauncherActivity extends AppCompatActivity {
                 return;
             }
             mDefaultUrl = metaData.getString(METADATA_DEFAULT_URL);
-            mStatusBarColor = ContextCompat.getColor(
-                    this, metaData.getInt(METADATA_STATUS_BAR_COLOR, android.R.color.white));
+            mStatusBarColor = metaData.getInt(METADATA_STATUS_BAR_COLOR, android.R.color.white);
         } catch (PackageManager.NameNotFoundException e) {
             // Will only happen if the package provided (the one we are running in) is not
             // installed - so should never happen.


### PR DESCRIPTION
Setting toolbar color ends up with runtime exception:
```
AndroidRuntime: FATAL EXCEPTION: main
    Process: ru.limezaim.www, PID: 8769
    java.lang.RuntimeException: Unable to start activity ComponentInfo{ru.limezaim.www/android.support.customtabs.trusted.LauncherActivity}: android.content.res.Resources$NotFoundException: Resource ID #0xff97c11f
```
**In this PR:**
Removed call of "ContextCompat.getColor" due searching resource with color value.
Now toolbar color sets correctly: http://joxi.ru/Vm660ggf43ovQm
