### PR TITLE
(bug) mSession is null [IllegalStateException]

### DIFF
--- a/customtabs/src/android/support/customtabs/trusted/TwaLauncher.java
+++ b/customtabs/src/android/support/customtabs/trusted/TwaLauncher.java
@@ -168,6 +168,7 @@ public class TwaLauncher {
             @Nullable SplashScreenStrategy splashScreenStrategy,
             @Nullable Runnable completionCallback) {
         if (mSession == null) {
+            // Some devices are throwing this exception
             throw new IllegalStateException("mSession is null in launchWhenSessionEstablished");
         }
 


### PR DESCRIPTION
# Description

I'm using the latest commit in production and some devices are throwing:

>  throw new IllegalStateException("mSession is null in launchWhenSessionEstablished");

Can you point me a direction to fix this?

## Attachments

![error](https://user-images.githubusercontent.com/11169832/62400871-2a6bc980-b557-11e9-89d4-7aaefae205f6.png)

```
java.lang.IllegalStateException: 
  at android.support.customtabs.trusted.TwaLauncher.launchWhenSessionEstablished (TwaLauncher.java:171)
  at android.support.customtabs.trusted.TwaLauncher.lambda$launchTwa$0$TwaLauncher (TwaLauncher.java:153)
  at android.support.customtabs.trusted.-$$Lambda$TwaLauncher$f0OnWewitepqy4BDJ8g8HMz1oZ8.run (Unknown Source:8)
  at android.support.customtabs.trusted.TwaLauncher$TwaCustomTabsServiceConnection.onCustomTabsServiceConnected (TwaLauncher.java:222)
  at android.support.customtabs.CustomTabsServiceConnection.onServiceConnected (CustomTabsServiceConnection.java:44)
  at android.app.LoadedApk$ServiceDispatcher.doConnected (LoadedApk.java:1839)
  at android.app.LoadedApk$ServiceDispatcher$RunConnection.run (LoadedApk.java:1871)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:6990)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1445)
```

![pie-charts](https://user-images.githubusercontent.com/11169832/62400898-48392e80-b557-11e9-82a7-4c555e9f28a7.png)